### PR TITLE
Merkle tree update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ wasm-bindgen-futures = "0.4.24"
 kvdb-memorydb = "0.9.0"
 wasm-bindgen-test = "0.3.24"
 test-case = "1.2.0"
+rand = "0.8.4"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.


### PR DESCRIPTION
Keep only root for Merkle tree subtrees that have only temporary elements.